### PR TITLE
gpg-agent: alignment with upstream & robust darwin enhancements 

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -3,7 +3,6 @@
 with lib;
 
 let
-
   cfg = config.services.gpg-agent;
   gpgPkg = config.programs.gpg.package;
 
@@ -15,12 +14,17 @@ let
     else
       "${pkgs.pinentry.${cfg.pinentryFlavor}}/bin/pinentry");
 
+  gpgSshSupportStr = ''
+    ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye > /dev/null
+  '';
+
   gpgInitStr = ''
     GPG_TTY="$(tty)"
     export GPG_TTY
-  '' + optionalString cfg.enableSshSupport
-    "${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye > /dev/null";
+  '' + optionalString cfg.enableSshSupport gpgSshSupportStr;
 
+  # for darwin systems, we explicitly override this as, by default, the system ssh-agent
+  # runs as a daemon, so this is already set.
   sshAuthSockStr =
     let sockPathCmd = "$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)";
     in (if pkgs.stdenv.hostPlatform.isLinux then ''
@@ -31,20 +35,22 @@ let
       export SSH_AUTH_SOCK="${sockPathCmd}"
     '');
 
+  gpgFishInitStr = ''
+    set -gx GPG_TTY (tty)
+  '' + optionalString cfg.enableSshSupport gpgSshSupportStr;
+
   # mimic `gpgconf` output for use in `systemd` unit definitions.
   # we cannot use `gpgconf` directly because it heavily depends on system
   # state, but we need the values at build time. original:
   # https://github.com/gpg/gnupg/blob/c6702d77d936b3e9d91b34d8fdee9599ab94ee1b/common/homedir.c#L672-L681
-  sockRelPath = dir:
+  gpgconf = dir:
     let
       hash =
         substring 0 24 (hexStringToBase32 (builtins.hashString "sha1" homedir));
     in if homedir == options.programs.gpg.homedir.default then
-      "gnupg/${dir}"
+      "%t/gnupg/${dir}"
     else
-      "gnupg/d.${hash}/${dir}";
-  gpgconf = dir: "%t/${sockRelPath dir}";
-  gpgconf' = dir: "/tmp/${sockRelPath dir}";
+      "%t/gnupg/d.${hash}/${dir}";
 
   # Act like `xxd -r -p | base32` but with z-base-32 alphabet and no trailing padding.
   # Written in Nix for purity.
@@ -82,7 +88,7 @@ let
   in hexString: (foldl' go initState (splitChars hexString)).ret;
 
 in {
-  meta.maintainers = with maintainers; [ rycee montchr ];
+  meta.maintainers = with maintainers; [ rycee montchr cmacrae ];
 
   options = {
     services.gpg-agent = {
@@ -215,8 +221,8 @@ in {
           <literal>gtk2</literal> for now.
           On macOS, while <literal>gtk2</literal> will work, the dialog
           will not receive proper focus.<literal>pinentry-mac</literal>
-          integrates with macOS smoothly, so it will be used as the default
-          on macOS. On Darwin (as opposed to macOS specifically),
+          integrates with macOS smoothly, so it will be used as the default.
+          On Darwin (as opposed to macOS specifically),
           <literal>gtk2</literal> may still be a preferable default.
         '';
       };
@@ -237,29 +243,32 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
-      home.file."${homedir}/gpg-agent.conf".text = concatStringsSep "\n"
-        (optional (cfg.enableSshSupport) "enable-ssh-support"
-          ++ optional cfg.grabKeyboardAndMouse "grab"
-          ++ optional (!cfg.enableScDaemon) "disable-scdaemon"
-          ++ optional (cfg.defaultCacheTtl != null)
-          "default-cache-ttl ${toString cfg.defaultCacheTtl}"
-          ++ optional (cfg.defaultCacheTtlSsh != null)
-          "default-cache-ttl-ssh ${toString cfg.defaultCacheTtlSsh}"
-          ++ optional (cfg.maxCacheTtl != null)
-          "max-cache-ttl ${toString cfg.maxCacheTtl}"
-          ++ optional (cfg.maxCacheTtlSsh != null)
-          "max-cache-ttl-ssh ${toString cfg.maxCacheTtlSsh}"
-          ++ optional (cfg.pinentryFlavor != null)
-          "pinentry-program ${pinentryBinPath}" ++ [ cfg.extraConfig ]);
+      home.file."${homedir}/gpg-agent.conf" = {
+        text = concatStringsSep "\n"
+          (optional (cfg.enableSshSupport) "enable-ssh-support"
+            ++ optional cfg.grabKeyboardAndMouse "grab"
+            ++ optional (!cfg.enableScDaemon) "disable-scdaemon"
+            ++ optional (cfg.defaultCacheTtl != null)
+            "default-cache-ttl ${toString cfg.defaultCacheTtl}"
+            ++ optional (cfg.defaultCacheTtlSsh != null)
+            "default-cache-ttl-ssh ${toString cfg.defaultCacheTtlSsh}"
+            ++ optional (cfg.maxCacheTtl != null)
+            "max-cache-ttl ${toString cfg.maxCacheTtl}"
+            ++ optional (cfg.maxCacheTtlSsh != null)
+            "max-cache-ttl-ssh ${toString cfg.maxCacheTtlSsh}"
+            ++ optional (cfg.pinentryFlavor != null)
+            "pinentry-program ${pinentryBinPath}" ++ [ cfg.extraConfig ]);
+        onChange =
+          optionalString pkgs.stdenv.hostPlatform.isDarwin gpgSshSupportStr;
+      };
 
       home.sessionVariablesExtra =
         optionalString cfg.enableSshSupport sshAuthSockStr;
 
       programs.bash.initExtra = mkIf cfg.enableBashIntegration gpgInitStr;
       programs.zsh.initExtra = mkIf cfg.enableZshIntegration gpgInitStr;
-      programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-        set -gx GPG_TTY (tty)
-      '';
+      programs.fish.interactiveShellInit =
+        mkIf cfg.enableFishIntegration gpgFishInitStr;
     }
 
     (mkIf (cfg.sshKeys != null) {
@@ -269,99 +278,98 @@ in {
       '') cfg.sshKeys;
     })
 
+    {
+      launchd.agents.gpg-agent = {
+        enable = true;
+        config = {
+          ProgramArguments = [ "${gpgPkg}/bin/gpgconf" "--launch" "gpg-agent" ]
+            ++ optionals cfg.verbose [ "--verbose" ];
+          RunAtLoad = true;
+          KeepAlive.SuccessfulExit = false;
+          EnvironmentVariables.GNUPGHOME = homedir;
+        };
+      };
+    }
+
     # The systemd units below are direct translations of the
     # descriptions in the
     #
     #   ${gpgPkg}/share/doc/gnupg/examples/systemd-user
     #
     # directory.
-    (mkIf (pkgs.stdenv.hostPlatform.isLinux) (mkMerge [
-      {
-        systemd.user.services.gpg-agent = {
-          Unit = {
-            Description = "GnuPG cryptographic agent and passphrase cache";
-            Documentation = "man:gpg-agent(1)";
-            Requires = "gpg-agent.socket";
-            After = "gpg-agent.socket";
-            # This is a socket-activated service:
-            RefuseManualStart = true;
-          };
-
-          Service = {
-            ExecStart = "${gpgPkg}/bin/gpg-agent --supervised"
-              + optionalString cfg.verbose " --verbose";
-            ExecReload = "${gpgPkg}/bin/gpgconf --reload gpg-agent";
-            Environment = [ "GNUPGHOME=${homedir}" ];
-          };
+    {
+      systemd.user.services.gpg-agent = {
+        Unit = {
+          Description = "GnuPG cryptographic agent and passphrase cache";
+          Documentation = "man:gpg-agent(1)";
+          Requires = "gpg-agent.socket";
+          After = "gpg-agent.socket";
+          # This is a socket-activated service:
+          RefuseManualStart = true;
         };
 
-        systemd.user.sockets.gpg-agent = {
-          Unit = {
-            Description = "GnuPG cryptographic agent and passphrase cache";
-            Documentation = "man:gpg-agent(1)";
-          };
-
-          Socket = {
-            ListenStream = gpgconf "S.gpg-agent";
-            FileDescriptorName = "std";
-            SocketMode = "0600";
-            DirectoryMode = "0700";
-          };
-
-          Install = { WantedBy = [ "sockets.target" ]; };
+        Service = {
+          ExecStart = "${gpgPkg}/bin/gpg-agent --supervised"
+            + optionalString cfg.verbose " --verbose";
+          ExecReload = "${gpgPkg}/bin/gpgconf --reload gpg-agent";
+          Environment = [ "GNUPGHOME=${homedir}" ];
         };
-      }
+      };
 
-      (mkIf cfg.enableSshSupport {
-        systemd.user.sockets.gpg-agent-ssh = {
-          Unit = {
-            Description = "GnuPG cryptographic agent (ssh-agent emulation)";
-            Documentation =
-              "man:gpg-agent(1) man:ssh-add(1) man:ssh-agent(1) man:ssh(1)";
-          };
-
-          Socket = {
-            ListenStream = gpgconf "S.gpg-agent.ssh";
-            FileDescriptorName = "ssh";
-            Service = "gpg-agent.service";
-            SocketMode = "0600";
-            DirectoryMode = "0700";
-          };
-
-          Install = { WantedBy = [ "sockets.target" ]; };
+      systemd.user.sockets.gpg-agent = {
+        Unit = {
+          Description = "GnuPG cryptographic agent and passphrase cache";
+          Documentation = "man:gpg-agent(1)";
         };
-      })
 
-      (mkIf cfg.enableExtraSocket {
-        systemd.user.sockets.gpg-agent-extra = {
-          Unit = {
-            Description =
-              "GnuPG cryptographic agent and passphrase cache (restricted)";
-            Documentation = "man:gpg-agent(1) man:ssh(1)";
-          };
-
-          Socket = {
-            ListenStream = gpgconf "S.gpg-agent.extra";
-            FileDescriptorName = "extra";
-            Service = "gpg-agent.service";
-            SocketMode = "0600";
-            DirectoryMode = "0700";
-          };
-
-          Install = { WantedBy = [ "sockets.target" ]; };
+        Socket = {
+          ListenStream = gpgconf "S.gpg-agent";
+          FileDescriptorName = "std";
+          SocketMode = "0600";
+          DirectoryMode = "0700";
         };
-      })
-    ]))
 
-    (mkIf pkgs.stdenv.hostPlatform.isDarwin {
-      launchd.agents.gpg-agent = {
-        enable = true;
-        config = {
-          ProgramArguments = [ "${gpgPkg}/bin/gpg-connect-agent" "/bye" ];
-          RunAtLoad = cfg.enableSshSupport;
-          EnvironmentVariables = { GNUPGHOME = homedir; };
-          KeepAlive.SuccessfulExit = false;
+        Install = { WantedBy = [ "sockets.target" ]; };
+      };
+    }
+
+    (mkIf cfg.enableSshSupport {
+      systemd.user.sockets.gpg-agent-ssh = {
+        Unit = {
+          Description = "GnuPG cryptographic agent (ssh-agent emulation)";
+          Documentation =
+            "man:gpg-agent(1) man:ssh-add(1) man:ssh-agent(1) man:ssh(1)";
         };
+
+        Socket = {
+          ListenStream = gpgconf "S.gpg-agent.ssh";
+          FileDescriptorName = "ssh";
+          Service = "gpg-agent.service";
+          SocketMode = "0600";
+          DirectoryMode = "0700";
+        };
+
+        Install = { WantedBy = [ "sockets.target" ]; };
+      };
+    })
+
+    (mkIf cfg.enableExtraSocket {
+      systemd.user.sockets.gpg-agent-extra = {
+        Unit = {
+          Description =
+            "GnuPG cryptographic agent and passphrase cache (restricted)";
+          Documentation = "man:gpg-agent(1) man:ssh(1)";
+        };
+
+        Socket = {
+          ListenStream = gpgconf "S.gpg-agent.extra";
+          FileDescriptorName = "extra";
+          Service = "gpg-agent.service";
+          SocketMode = "0600";
+          DirectoryMode = "0700";
+        };
+
+        Install = { WantedBy = [ "sockets.target" ]; };
       };
     })
   ]);

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -3,12 +3,10 @@
 with lib;
 
 let
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
 
-  socketPath = if isDarwin then
-    config.launchd.agents.gpg-agent.config.Sockets.ssh.SockPathName
-  else
-    config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
+  socketPath =
+    mkIf isLinux config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
 
 in {
   config = {
@@ -18,8 +16,9 @@ in {
 
     test.stubs.gnupg = { };
 
-    nmt.script = ''
+    nmt.script = optionalString isLinux ''
       in="${socketPath}"
+    '' + ''
       if [[ $in != "%t/gnupg/S.gpg-agent" ]]
       then
         echo $in

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -3,12 +3,10 @@
 with lib;
 
 let
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
 
-  socketPath = if isDarwin then
-    config.launchd.agents.gnupg-agent.config.Sockets.ssh.SockPathName
-  else
-    config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
+  socketPath =
+    mkIf isLinux config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
 
 in {
   config = {
@@ -21,8 +19,9 @@ in {
 
     test.stubs.gnupg = { };
 
-    nmt.script = ''
+    nmt.script = optionalString isLinux ''
       in="${socketPath}"
+    '' + ''
       if [[ $in != "%t/gnupg/d.wp4h7ks5zxy4dodqadgpbbpz/S.gpg-agent" ]]
       then
         echo $in


### PR DESCRIPTION
Here are the changes mentioned in nix-community/home-manager#2964 :)  
Obviously, you'll want to rebase this into your branch (either that, or rebase your branch from upstream first), as it brings in a bunch of stuff from upstream.  

To help you through the commit-sludge, here are the relevant changes:  
- [module](https://github.com/montchr/home-manager/compare/trunk...cmacrae:feat/gpg-agent-darwin?expand=1#diff-1eb850a1ba8d791669c3da845dbf1aef05aacb36173e0455881f012f45cf2c34)
- [test (default homedir)](https://github.com/montchr/home-manager/compare/trunk...cmacrae:feat/gpg-agent-darwin?expand=1#diff-af756363654efca06037e9e968de00b5004e553b35a0357b78c1d4f4e61f3394)
- [test (override homedir)](https://github.com/montchr/home-manager/compare/trunk...cmacrae:feat/gpg-agent-darwin?expand=1#diff-2c233a3d5f1ab1da5a947dbe1de56077e55e2a180706ff3f62a491d5355a3cd3)
